### PR TITLE
Update signature for `XetDownloader.download` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Then add the dependency to your target:
 ### Downloading a File
 
 To download a file, you need:
+
 - A **file ID**: the 64-character hex hash from the `X-Xet-Hash` response header
 - A **refresh URL**: the Hub endpoint for obtaining CAS access tokens
 
@@ -64,7 +65,7 @@ let downloader = XetDownloader(
 let data = try await downloader.data(for: fileID)
 
 // Download to disk
-try await downloader.download(for: fileID, to: destinationURL)
+try await downloader.download(fileID, to: destinationURL)
 ```
 
 ### Partial Downloads
@@ -113,8 +114,9 @@ The Xet protocol reconstructs files from deduplicated, compressed chunks:
 
 ### Xorb Format
 
-Files are stored as *xorbs* (Xet Orbs)—sequences of compressed chunks.
+Files are stored as _xorbs_ (Xet Orbs)—sequences of compressed chunks.
 Each chunk has an 8-byte header specifying:
+
 - Version (1 byte)
 - Compressed size (3 bytes, little-endian)
 - Compression scheme (1 byte): none, LZ4, or BG4+LZ4

--- a/Sources/Xet/Xet.swift
+++ b/Sources/Xet/Xet.swift
@@ -24,7 +24,7 @@ import Foundation
 /// Download a file to disk:
 ///
 /// ```swift
-/// try await downloader.download(for: fileID, to: destinationURL)
+/// try await downloader.download(fileID, to: destinationURL)
 /// ```
 ///
 /// Both methods support partial downloads via the `byteRange` parameter.
@@ -87,7 +87,7 @@ public struct XetDownloader: Sendable {
     ///   or `URLError` for network failures.
     ///
     /// - Important: This method loads the entire file (or range) into memory.
-    ///   For large files, use ``download(for:byteRange:to:)``
+    ///   For large files, use ``download(_:byteRange:to:)``
     ///   to write directly to disk instead.
     public func data(
         for fileID: String,
@@ -126,7 +126,7 @@ public struct XetDownloader: Sendable {
     ///   or file system errors if writing to disk fails.
     @discardableResult
     public func download(
-        for fileID: String,
+        _ fileID: String,
         byteRange: Range<UInt64>? = nil,
         to destinationURL: URL
     ) async throws -> Int64 {

--- a/Sources/Xet/Xet.swift
+++ b/Sources/Xet/Xet.swift
@@ -116,6 +116,8 @@ public struct XetDownloader: Sendable {
     ///     making any network requests.
     ///   - destinationURL: The file URL where contents will be written.
     ///     If a file exists at this path, it will be replaced.
+    ///   - fileManager: The file manager to use for file operations.
+    ///     Defaults to `.default`.
     ///
     /// - Returns: The number of bytes written.
     ///
@@ -128,14 +130,15 @@ public struct XetDownloader: Sendable {
     public func download(
         _ fileID: String,
         byteRange: Range<UInt64>? = nil,
-        to destinationURL: URL
+        to destinationURL: URL,
+        fileManager: FileManager = .default
     ) async throws -> Int64 {
+        if fileManager.fileExists(atPath: destinationURL.path) {
+            try fileManager.removeItem(at: destinationURL)
+        }
+        fileManager.createFile(atPath: destinationURL.path, contents: nil)
+
         if let byteRange, byteRange.isEmpty {
-            let fm = FileManager.default
-            if fm.fileExists(atPath: destinationURL.path) {
-                try fm.removeItem(at: destinationURL)
-            }
-            fm.createFile(atPath: destinationURL.path, contents: nil)
             return 0
         }
         let writer = try FileOutputWriter(destinationURL: destinationURL)
@@ -553,11 +556,6 @@ actor FileOutputWriter: OutputWriter {
     private let handle: FileHandle
 
     init(destinationURL: URL) throws {
-        let fm = FileManager.default
-        if fm.fileExists(atPath: destinationURL.path) {
-            try fm.removeItem(at: destinationURL)
-        }
-        fm.createFile(atPath: destinationURL.path, contents: nil)
         self.handle = try FileHandle(forWritingTo: destinationURL)
     }
 

--- a/Sources/Xet/Xorb.swift
+++ b/Sources/Xet/Xorb.swift
@@ -9,12 +9,12 @@ import Foundation
 ///
 /// ## Chunk Header Format
 ///
-/// | Bytes | Field | Description |
-/// |-------|-------|-------------|
-/// | 0 | Version | Protocol version (currently 0) |
-/// | 1-3 | Compressed Size | Little-endian 24-bit integer |
-/// | 4 | Compression Type | 0=none, 1=LZ4, 2=BG4+LZ4 |
-/// | 5-7 | Uncompressed Size | Little-endian 24-bit integer |
+/// | Bytes |         Field        |              Description                 |
+/// |------:|:---------------------|:-----------------------------------------|
+/// |   0   | Version              | Protocol version (currently 0)           |
+/// | 1-3   | Compressed Size      | Little-endian 24-bit integer             |
+/// |   4   | Compression Type     | 0=none, 1=LZ4, 2=BG4+LZ4                 |
+/// | 5-7   | Uncompressed Size    | Little-endian 24-bit integer             |
 ///
 /// ## Usage
 ///

--- a/Tests/XetTests/IntegrationTests.swift
+++ b/Tests/XetTests/IntegrationTests.swift
@@ -111,7 +111,7 @@ struct IntegrationTests {
 
         let range: Range<UInt64> = 0 ..< (256 * 1024)
         let bytesWritten = try await downloader.download(
-            for: fileID,
+            fileID,
             byteRange: range,
             to: destinationURL
         )


### PR DESCRIPTION
We are downloading _the file (by its ID)_. Its complement, `data(for:...)` is getting the data _for the file_.

Also, it's nice to take explicit `FileManager` parameter so that we can do dependency injection.