### PR TITLE
Add `NIOTransportServices` as explicit dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,8 @@ let package = Package(
         .package(url: "https://github.com/swift-server/async-http-client", from: "1.28.0"),
         // 2.81.0: minimum required by async-http-client 1.28.0+
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.81.0"),
+        // Explicit dependency for NIOTSEventLoopGroup; Xcode doesn't propagate transitive deps when building as frameworks
+        .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.24.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -34,6 +36,7 @@ let package = Package(
                 .product(name: "AsyncHTTPClient", package: "async-http-client"),
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
+                .product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
             ]
         ),
         .testTarget(


### PR DESCRIPTION
Resolves #6 

Xcode doesn't propagate transitive dependencies when building Swift Package Manager packages as frameworks, which caused undefined symbols for `NIOTSEventLoopGroup`.